### PR TITLE
Fixed typo, for autocomplete

### DIFF
--- a/docs/autocomplete.rst
+++ b/docs/autocomplete.rst
@@ -30,7 +30,7 @@ To begin, call :py:meth:`Database.autocomplete` to create an instance of the aut
 .. code-block:: pycon
 
     >>> database = Database()
-    >>> ac = database.Autocomplete()
+    >>> ac = database.autocomplete()
 
 Phrases can be stored by calling :py:meth:`Autocomplete.store`:
 


### PR DESCRIPTION
I was following this documentation and could not do database.Autocomplete(), did some investigation (looked in the source) and realized that this was a typo in the documentaiton. it should be database.autocomplete()