### PR TITLE
Make Autocomplete.search respect the limit parameter

### DIFF
--- a/walrus/autocomplete.py
+++ b/walrus/autocomplete.py
@@ -296,7 +296,7 @@ class Autocomplete(object):
                 if orig_score != score:
                     results[raw_id] = score
 
-        return self._load_objects(results[0:0], limit)
+        return self._load_objects(results[:limit], limit)
 
     def get_cache_key(self, phrases, boosts):
         if boosts:


### PR DESCRIPTION
Python passes by assignment, so when you passed results[0:0] it created the list. My project is working with a *very* large data set (hundreds of thousands of keys) and this was creating significant slowdowns when requesting data. It's not the prettiest fix, but it works much faster now when dealing with large data sets.