### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Lightweight Python utilities for working with [Redis](http://redis.io).
 The purpose of [walrus](https://github.com/coleifer/walrus) is to make working with Redis in Python a little easier by wrapping rich objects in Pythonic containers. walrus consists of:
 
 * Wrappers for the Redis object types:
-    * [Hash](https://walrus.readthedocs.org/en/latest/containers.html#hashes)
-    * [List](https://walrus.readthedocs.org/en/latest/containers.html#lists)
-    * [Set](https://walrus.readthedocs.org/en/latest/containers.html#sets)
-    * [Sorted Set](https://walrus.readthedocs.org/en/latest/containers.html#sorted-sets-zset)
-    * [HyperLogLog](https://walrus.readthedocs.org/en/latest/containers.html#hyperloglog)
-    * [Array](https://walrus.readthedocs.org/en/latest/containers.html#arrays) (custom type)
-* A simple [Cache](https://walrus.readthedocs.org/en/latest/cache.html) implementation that exposes several decorators for caching function and method calls.
-* Lightweight data [Model](https://walrus.readthedocs.org/en/latest/models.html) objects that support persisting structured information and performing complex queries using secondary indexes.
+    * [Hash](https://walrus.readthedocs.io/en/latest/containers.html#hashes)
+    * [List](https://walrus.readthedocs.io/en/latest/containers.html#lists)
+    * [Set](https://walrus.readthedocs.io/en/latest/containers.html#sets)
+    * [Sorted Set](https://walrus.readthedocs.io/en/latest/containers.html#sorted-sets-zset)
+    * [HyperLogLog](https://walrus.readthedocs.io/en/latest/containers.html#hyperloglog)
+    * [Array](https://walrus.readthedocs.io/en/latest/containers.html#arrays) (custom type)
+* A simple [Cache](https://walrus.readthedocs.io/en/latest/cache.html) implementation that exposes several decorators for caching function and method calls.
+* Lightweight data [Model](https://walrus.readthedocs.io/en/latest/models.html) objects that support persisting structured information and performing complex queries using secondary indexes.
 
 ### Models
 
@@ -28,4 +28,4 @@ Please open a [github issue](https://github.com/coleifer/walrus/issues/new) and 
 
 ### Alternative Backends
 
-Walrus also can integrate with the Redis-like databases [rlite](https://github.com/seppo0010/rlite), [ledis](http://ledisdb.com/), and [vedis](http://vedis.symisc.net). Check the [documentation](http://walrus.readthedocs.org/en/latest/alt-backends.html) for more details.
+Walrus also can integrate with the Redis-like databases [rlite](https://github.com/seppo0010/rlite), [ledis](http://ledisdb.com/), and [vedis](http://vedis.symisc.net). Check the [documentation](https://walrus.readthedocs.io/en/latest/alt-backends.html) for more details.

--- a/docs/alt-backends.rst
+++ b/docs/alt-backends.rst
@@ -80,7 +80,7 @@ The project's features are:
 * Includes fast low-level key/value store.
 * Thread-safe and fully re-entrant.
 * Support for Terabyte-sized databases.
-* `Python bindings <http://vedis-python.readthedocs.org/en/latest/>`_ allow you to `write your own Vedis commands in Python <http://vedis-python.readthedocs.org/en/latest/custom_commands.html>`_.
+* `Python bindings <https://vedis-python.readthedocs.io/en/latest/>`_ allow you to `write your own Vedis commands in Python <https://vedis-python.readthedocs.io/en/latest/custom_commands.html>`_.
 
 Use-cases for ``Vedis``:
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -12,7 +12,7 @@ Let's see how this works by using ``walrus`` in the Python interactive shell. Ma
 Introducing walrus
 ------------------
 
-To begin using walrus, we'll start by importing it and creating a :py:class:`Database` instance. The ``Database`` object is a thin wrapper over the `redis-py <https://redis-py.readthedocs.org/>`_ ``Redis`` class, so any methods available on ``Redis`` will also be available on the walrus ``Database`` object.
+To begin using walrus, we'll start by importing it and creating a :py:class:`Database` instance. The ``Database`` object is a thin wrapper over the `redis-py <https://redis-py.readthedocs.io/>`_ ``Redis`` class, so any methods available on ``Redis`` will also be available on the walrus ``Database`` object.
 
 .. code-block:: pycon
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.