### PR TITLE
Modify to encode to UTF-8 to fix unicode string issues on join.

### DIFF
--- a/walrus/__init__.py
+++ b/walrus/__init__.py
@@ -4,7 +4,7 @@ Lightweight Python utilities for working with Redis.
 
 __author__ = 'Charles Leifer'
 __license__ = 'MIT'
-__version__ = '0.3.4'
+__version__ = '0.3.5'
 
 #               ___
 #            .-9 9 `\

--- a/walrus/graph.py
+++ b/walrus/graph.py
@@ -130,7 +130,8 @@ class Graph(object):
             parts.extend(('pso', p))
         elif o:
             parts.extend(('osp', o))
-        return key(parts + ['']), key(parts + ['\xff'])
+        return key(parts + ['']), \
+               key(parts + ['\xff'.decode("utf-8", "replace")])
 
     def query(self, s=None, p=None, o=None):
         """


### PR DESCRIPTION
Fixes #48 

Set it to decode the \xff bytestring to UTF-8 with replacement to support joining the string with unicode strings.

Not sure if you want to fix it this way, but it resolves the issues I was running into.