### PR TITLE
Tweaks to locking based on TTL behavior

### DIFF
--- a/walrus/database.py
+++ b/walrus/database.py
@@ -198,7 +198,7 @@ class Database(Redis):
         """
         return Graph(self, name, *args, **kwargs)
 
-    def lock(self, name, ttl=None, lock_id=None):
+    def lock(self, name, ttl=None, lock_id=None, lock_test_delay=None):
         """
         Create a named :py:class:`Lock` instance. The lock implements
         an API similar to the standard library's ``threading.Lock``,
@@ -209,8 +209,10 @@ class Database(Redis):
             (optional). If the ttl is ``None`` then the lock will not
             expire.
         :param str lock_id: Optional identifier for the lock instance.
+        :param int lock_test_delay: The time between polls when trying to
+            acquire lock.  Defaults to TTL if not defined.
         """
-        return Lock(self, name, ttl, lock_id)
+        return Lock(self, name, ttl, lock_id, lock_test_delay)
 
     def rate_limit(self, name, limit=5, per=60, debug=False):
         """

--- a/walrus/tests.py
+++ b/walrus/tests.py
@@ -1255,8 +1255,8 @@ class TestLock(WalrusTestCase):
         lock_a = db.lock('lock-ttl', ttl=5000)
 
         def wait_for_blocking_acquire():
-            lock_a2 = db.lock('lock-ttl', ttl=5000)
-            lock_a2.acquire(lock_test_delay=500)
+            lock_a2 = db.lock('lock-ttl', ttl=5000, lock_test_delay=500)
+            lock_a2.acquire()
             lock_a2.release()
 
         self.assertTrue(lock_a.acquire())


### PR DESCRIPTION
Couple of tweaks to locking based on things I recently discovered:

- blpop operation on lock acquisition expects seconds, so a long TTL can have a very long blocking operation if a release never occurs (for example, the test I added would originally have a 5000 second blpop operation so it would take over an hour before it tries to acquire the lock again).  It ends up looking like a deadlock.
- Add an additional parameter to refine the blpop timeout.  Defaulting to the TTL value could potentially double the TTL (X locks with 5 second TTL, Y tries to acquire 4 seconds in and fails; blocks on the blpop and waits an additional 5 seconds before trying again; Y finally acquires at 9 seconds).  That's not bad, but I'd like to be able to refine that polling period when I have a larger TTL value.
- Added test to validate the scenario, where A never releases but B is able to acquire after TTL expires.