### PR TITLE
Raise a KeyError when removing a non existing object in autocomplete

### DIFF
--- a/walrus/autocomplete.py
+++ b/walrus/autocomplete.py
@@ -156,6 +156,9 @@ class Autocomplete(object):
         :param obj_id: The object's unique identifier.
         :param obj_type: The object's type.
         """
+        if not self.exists(obj_id, obj_type):
+            raise KeyError('Object not found.')
+
         combined_id = self.object_key(obj_id, obj_type)
         title = self._title_data[combined_id]
 

--- a/walrus/tests.py
+++ b/walrus/tests.py
@@ -1484,6 +1484,10 @@ class TestAutocomplete(WalrusTestCase):
         results = self.autocomplete.search('testing')
         self.assertResults(results, [1, 3])
 
+        # `2` has already been removed
+        with self.assertRaises(KeyError):
+            self.autocomplete.remove(2)
+
     def test_tokenize_title(self):
         self.assertEqual(
             self.autocomplete.tokenize_title('abc def ghi'),


### PR DESCRIPTION
Context: we're talking about the `remove` method in autocomplete.

When removing a object that hasn't been registered or was already removed, `title` values `None` when retrieved from the db:

```python
title = self._title_data[combined_id]
```

Then when calling `tokenize_title` the next line:
```python
for word in self.tokenize_title(title):
```
it is assumed that title is a string, but in this case, it is not. It thus crashes when the `lower` method is called in `tokenize_title`.

```shell
======================================================================
ERROR: test_removing_objects (walrus.tests.TestAutocomplete)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vagrant/code/walrus/walrus/tests.py", line 1489, in test_removing_objects
    self.autocomplete.remove(2)
  File "/home/vagrant/code/walrus/walrus/autocomplete.py", line 162, in remove
    for word in self.tokenize_title(title):
  File "/home/vagrant/code/walrus/walrus/autocomplete.py", line 60, in tokenize_title
    phrase = re.sub('[^a-z0-9_\-\s]', '', phrase.lower())
AttributeError: 'NoneType' object has no attribute 'lower'

----------------------------------------------------------------------
```

It is manageable, by calling explicitly `exists` before `remove` on my part, but in any case, it seems weird to get an `AttributeError` when the object isn't found.

What I'm offering is handling cases where the object isn't found. I'm proposing the loud way, raising explicitly a `KeyError`.

I could also go the other way, and exit the method:
```python
if not self.exists(obj_id, obj_type):
    return
```

Watchasay?

Cheers