### PR TITLE
fix setex arguments order

### DIFF
--- a/walrus/cache.py
+++ b/walrus/cache.py
@@ -75,7 +75,7 @@ class Cache(object):
         pickled_value = pickle.dumps(value)
         self.metrics['writes'] += 1
         if timeout:
-            return self.database.setex(key, int(timeout), pickled_value)
+            return self.database.setex(key, pickled_value, int(timeout))
         else:
             return self.database.set(key, pickled_value)
 


### PR DESCRIPTION
I got the `ResponseError: value is not an integer or out of range` exception when trying to use the cache decorator with timeout, which leads me to this stackoverflow answer:

https://stackoverflow.com/questions/47856750/redis-setex-value-is-not-an-integer-or-out-of-range

but it seems like my patch was not quite right, I'm still looking into it.