### PR TITLE
Add version dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author='Charles Leifer',
     author_email='coleifer@gmail.com',
     url='http://github.com/coleifer/walrus/',
-    install_requires=['redis'],
+    install_requires=['redis>=3.0.0'],
     packages=find_packages(),
     package_data={
         'walrus': [


### PR DESCRIPTION
Should resolve the issue that lead to #78.

The version dependency described in the requirements.txt file is good, but pip wouldn't automatically resolve a down-rev redis-py when upgrading to the latest walrus.  Adding the version description to install_requires should tell pip to upgrade redis-py if necessary.