### PR TITLE
Setnx method on the Hash object.

### DIFF
--- a/walrus/containers.py
+++ b/walrus/containers.py
@@ -182,6 +182,14 @@ class Hash(Container):
         else:
             return list(self)
 
+    def setnx(self, key, value):
+        """
+        Set ``key`` to ``value`` if ``key`` does not exist.
+
+        :returns: True if successfully set or False if the key already existed.
+        """
+        return bool(self.database.hsetnx(self.key, key, value))
+
     @chainable_method
     def update(self, *args, **kwargs):
         """

--- a/walrus/tests/containers.py
+++ b/walrus/tests/containers.py
@@ -67,6 +67,11 @@ class TestHash(WalrusTestCase):
         hsh = Hash.from_dict(db, 'test', data)
         self.assertEqual(hsh.as_dict(True), data)
 
+    def test_setnx(self):
+        key, value = "key_setnx", "value_setnx"
+        self.assertTrue(self.hsh.setnx(key, value))
+        self.assertFalse(self.hsh.setnx(key, value))
+
 
 class TestSet(WalrusTestCase):
     def setUp(self):


### PR DESCRIPTION
I was going to create an issue, but figured it was just as easy to do this myself. I implemented the `setnx` method in the Hash container object. This exposes the method in a more logical manner. I also added a test. I hope this is okay with you! 