### PR TITLE
Handle OverflowError in IntegerField.db_value()

### DIFF
--- a/walrus/models.py
+++ b/walrus/models.py
@@ -142,7 +142,14 @@ class IntegerField(_ScalarField):
     _coerce = int
 
     def db_value(self, value):
-        return 0 if value is None else int(value)
+        if value is None:
+            return 0
+        try:
+            return int(value)
+        except (ValueError, TypeError, OverflowError) as exc:
+            raise TypeError(
+                'IntegerField value cannot be converted to int: %r' % value
+            ) from exc
 
 
 class AutoIncrementField(IntegerField):


### PR DESCRIPTION
`IntegerField.db_value()` converts values to `int` using a one-liner with no exception handling:

```python
return 0 if value is None else int(value)
```

`int(float('inf'))` raises `OverflowError: cannot convert float infinity to integer`, which is not caught. This gives a confusing traceback instead of a clear error message.

**Fix:** Expand `db_value()` to use a try/except block catching `(ValueError, TypeError, OverflowError)` and raise a descriptive `TypeError`.

Reproduction:
```python
from walrus import IntegerField
IntegerField().db_value(float('inf'))  # OverflowError: cannot convert float infinity to integer
```